### PR TITLE
Makefile: provide 'clean' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ DSPDIR = ${prefix}/share/qcom
 
 all:
 
+clean:
+
 install:
 	./scripts/install.sh config.txt ${DESTDIR}/${DSPDIR}
 


### PR DESCRIPTION
It's useful to provide a 'make clean' target as a lot of scripts expect to be able to run it. Add empty 'clean' target to make those scripts happy.