### PR TITLE
DSP binaries for IQ8275-EVK & IQ9075-EVK platforms

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -46,3 +46,7 @@ Install: qcs8300/Qualcomm/QCS8300-RIDE	gdsp0	gdsp0-DSP.AT.1.0.1-00163-LEMANS-1
 Install: qcs615/Qualcomm/QCS615-RIDE	adsp	adsp-ADSP.VT.5.2.c6-00059-SM6150-1
 Install: qcs615/Qualcomm/QCS615-RIDE	cdsp	cdsp-CDSP.VT.2.2.c4-00019-SM6150-1
 
+# IQ8275 EVK
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0

--- a/config.txt
+++ b/config.txt
@@ -50,3 +50,10 @@ Install: qcs615/Qualcomm/QCS615-RIDE	cdsp	cdsp-CDSP.VT.2.2.c4-00019-SM6150-1
 Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
 Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
 Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0
+
+# IQ9075 EVK
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp1
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp0
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp1

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -85,21 +85,28 @@ def load_whence():
 def load_config():
     with open("config.txt", encoding="utf-8") as file:
         pattern_empty = re.compile("^#|^$")
-        pattern_data = re.compile("Install: ([^ \t]+)[ \t]+([^ \t]+)[ \t]+([^ \t]+)\n")
+        pattern_install = re.compile("Install: ([^ \t]+)[ \t]+([^ \t]+)[ \t]+([^ \t]+)\n")
+        pattern_link = re.compile("Link: ([^ \t]+)[ \t]+([^ \t]+)\n")
 
         for (lineno, line) in enumerate(file, start=1):
             if pattern_empty.match(line):
                 continue
-            match = pattern_data.match(line)
+
+            match = pattern_install.match(line)
             if match:
-                yield (lineno, match.group(1), match.group(2), match.group(3))
+                yield ("install", lineno, *match.groups())
+                continue
+
+            match = pattern_link.match(line)
+            if match:
+                yield ("link", lineno, *match.groups())
                 continue
 
             raise Exception("config.txt: %d: failed to parse '%s'" % (lineno, line[:-1]))
 
 DSPS = [ "adsp", "cdsp", "sdsp", "cdsp1", "gdsp0", "gdsp1" ]
 
-def check_config(data, dirs):
+def check_install_config(data, dirs):
     (lineno, path, dsp, subdir) = data
     ret = True
 
@@ -119,6 +126,40 @@ def check_config(data, dirs):
     if dsp not in DSPS:
         sys.stderr.write("config.txt: %d: unknown DSP type '%s'\n" % (lineno, dsp))
         ret = False
+
+    return ret
+
+def check_link_config(data):
+    (lineno, src_path, dst_path) = data
+    ret = True
+
+    if src_path.endswith("/"):
+        sys.stderr.write("config.txt: %d: trailing '/' in %s\n" % (lineno, src_path))
+        ret = False
+
+    if dst_path.endswith("/"):
+        sys.stderr.write("config.txt: %d: trailing '/' in %s\n" % (lineno, dst_path))
+        ret = False
+
+    dsp_path = os.path.dirname(src_path)
+    sourcedir = os.path.dirname(dsp_path)
+    if not os.path.exists(sourcedir):
+        sys.stderr.write("config.txt: %d: dir %s doesn't exist\n" % (lineno, sourcedir))
+        ret = False
+
+    if os.path.basename(dsp_path) != "dsp":
+        sys.stderr.write("config.txt: %d: DSP type not under 'dsp' dir %s\n" % (lineno, src_path))
+        ret = False
+
+    return ret
+
+def check_config(data, dirs):
+    ret = True
+
+    if data[0] == "install":
+       ret = check_install_config(data[1:], dirs)
+    elif data[0] == "link":
+       ret = check_link_config(data[1:])
 
     return ret
 


### PR DESCRIPTION
IQ8275-EVK & IQ9075-EVK  platforms use the same DSP binaries that of existing platforms. To avoid duplication, update `config.txt` to link those to the existing paths as appropriate.