### PR TITLE
scripts/release: use ASCII armoured signatures

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,4 +6,4 @@ set -e
 make check
 git tag -s -m "Hexagon DSP binaries, release $1" $1
 make dist
-gpg --sign -b dist/hexagon-dsp-binaries_$1.tar.gz
+gpg --sign -b -a dist/hexagon-dsp-binaries_$1.tar.gz


### PR DESCRIPTION
Create ASCII rather than binary signatures, they are easier to handle.