### PR TITLE
scripts/check: don't choke on missing subdirs

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -181,6 +181,10 @@ def check_dir(subdir):
 
     okay = True
 
+    # We alrady warned earlier
+    if not os.path.exists(subdir):
+        return False
+
     for file in os.listdir(subdir):
         fullname = os.path.join(subdir, file)
 


### PR DESCRIPTION
The check.py script already warns about missing dirs. Don't choke on them in check_dirs(), fixing the following crash:

```
Traceback (most recent call last):
  File "/home/lumag/Projects/Qcomm/Firmware/hexagon-dsp-binaries/./scripts/check.py", line 249, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/lumag/Projects/Qcomm/Firmware/hexagon-dsp-binaries/./scripts/check.py", line 242, in main
    if not check_dir(entry):
           ~~~~~~~~~^^^^^^^
  File "/home/lumag/Projects/Qcomm/Firmware/hexagon-dsp-binaries/./scripts/check.py", line 184, in check_dir
    for file in os.listdir(subdir):
                ~~~~~~~~~~^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'qcs615/Qualcomm/foo/bar'
```