### PR TITLE
Implement copy operation for install and dist

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -50,13 +50,13 @@ Install: qcs615/Qualcomm/QCS615-RIDE	cdsp	CDSP.VT.2.2.c4-00019-SM6150-1
 Install: x1e80100/Qualcomm/Hamoa-IoT-EVK	cdsp	CDSP.HT.2.9.c1-00069-HAMOA-1
 
 # IQ8275 EVK
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0
+Copy: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
+Copy: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
+Copy: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0
 
 # IQ9075 EVK
-Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp
-Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp
-Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp1
-Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp0
-Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp1
+Copy: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp
+Copy: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp
+Copy: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/cdsp1
+Copy: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp0
+Copy: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gdsp1

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -87,6 +87,7 @@ def load_config():
         pattern_empty = re.compile("^#|^$")
         pattern_install = re.compile("Install: ([^ \t]+)[ \t]+([^ \t]+)[ \t]+([^ \t]+)\n")
         pattern_link = re.compile("Link: ([^ \t]+)[ \t]+([^ \t]+)\n")
+        pattern_copy = re.compile("Copy: ([^ \t]+)[ \t]+([^ \t]+)\n")
 
         for (lineno, line) in enumerate(file, start=1):
             if pattern_empty.match(line):
@@ -100,6 +101,11 @@ def load_config():
             match = pattern_link.match(line)
             if match:
                 yield ("link", lineno, *match.groups())
+                continue
+
+            match = pattern_copy.match(line)
+            if match:
+                yield ("copy", lineno, *match.groups())
                 continue
 
             raise Exception("config.txt: %d: failed to parse '%s'" % (lineno, line[:-1]))
@@ -159,6 +165,8 @@ def check_config(data, dirs):
     if data[0] == "install":
        ret = check_install_config(data[1:], dirs)
     elif data[0] == "link":
+       ret = check_link_config(data[1:])
+    elif data[0] == "copy":
        ret = check_link_config(data[1:])
 
     return ret

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -33,6 +33,16 @@ do_install() {
 	install -m 0644 "${srcdir}"/* "${dstdir}"
 }
 
+# dest target copy
+do_copy() {
+    local target="$1/$2"
+    local copy="$1/$3"
+
+    mkdir -p "`dirname "${copy}"`"
+    rm -rf "${copy}"
+    cp -a "${target}" "${copy}"
+}
+
 grep -v '^#\|^$' "${CFG}" | while read verb rest
 do
 	case ${verb} in
@@ -41,6 +51,9 @@ do
 		;;
 	"Link:" )
 		# ignore
+		;;
+	"Copy:" )
+		do_copy ${DST} ${rest}
 		;;
 	"*" )
 		echo "Unsupported clause ${verb}" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -66,6 +66,16 @@ do_link() {
 	ln -sr -T "${target}" "${link}"
 }
 
+# dest target copy
+do_copy() {
+	local target="$1/$2"
+	local copy="$1/$3"
+
+	mkdir -p "`dirname "${copy}"`"
+	rm -rf "${copy}"
+	cp -a "${target}" "${copy}"
+}
+
 grep -v '^#\|^$' "${CFG}" | while read verb rest
 do
 	case ${verb} in
@@ -74,6 +84,9 @@ do
 		;;
 	"Link:" )
 		do_link ${DST} ${rest}
+		;;
+	"Copy:" )
+		do_copy ${DST} ${rest}
 		;;
 	* )
 		echo "Unsupported clause ${verb}" >&2


### PR DESCRIPTION
IQ boards uses similar DSP binaries as corresponding ride boards. Current Link implementation works fine for make install but causes problems when the files are getting packaged in distro. Copy the files instead of creating link to have the actual files installed instead of stale symlinks.