### PR TITLE
Add DSP_LIBRARY_PATH mappings for target machines

### DIFF
--- a/00-hexagon-dsp-binaries.yaml
+++ b/00-hexagon-dsp-binaries.yaml
@@ -1,0 +1,29 @@
+# Machine entries are sorted alphabetically by machine name (key)
+# This sorting order ensures maintainability and stability as new properties are added
+machines:
+  "Qualcomm SA8775P Ride":
+    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
+  "Qualcomm SA8775P Ride Rev3":
+    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
+  "Qualcomm Technologies, Inc. DB820c":
+    DSP_LIBRARY_PATH: "apq8096/Qualcomm/db820c/dsp"
+  "Qualcomm Technologies, Inc. Hamoa IoT EVK":
+    DSP_LIBRARY_PATH: "x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp"
+  "Qualcomm Technologies, Inc. Lemans EVK":
+    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/IQ9075-EVK/dsp"
+  "Qualcomm Technologies, Inc. Monaco EVK":
+    DSP_LIBRARY_PATH: "qcs8300/Qualcomm/IQ8275-EVK/dsp"
+  "Qualcomm Technologies, Inc. QCS615 Ride (IQ-615 Beta EVK)":
+    DSP_LIBRARY_PATH: "qcs615/Qualcomm/QCS615-RIDE/dsp"
+  "Qualcomm Technologies, Inc. QCS8300 Ride":
+    DSP_LIBRARY_PATH: "qcs8300/Qualcomm/QCS8300-RIDE/dsp"
+  "Qualcomm Technologies, Inc. QRB4210 RB2":
+    DSP_LIBRARY_PATH: "qrb4210/Thundercomm/RB2/dsp"
+  "Qualcomm Technologies, Inc. Robotics RB1":
+    DSP_LIBRARY_PATH: "qcm2290/Thundercomm/RB1/dsp"
+  "Qualcomm Technologies, Inc. Robotics RB3gen2":
+    DSP_LIBRARY_PATH: "qcm6490/Thundercomm/RB3gen2/dsp"
+  "Qualcomm Technologies, Inc. Robotics RB5":
+    DSP_LIBRARY_PATH: "sm8250/Thundercomm/RB5/dsp"
+  "Thundercomm Dragonboard 845c":
+    DSP_LIBRARY_PATH: "sdm845/Thundercomm/db845c/dsp"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ clean:
 
 install:
 	./scripts/install.sh config.txt ${DESTDIR}/${DSPDIR}
+	install -D -m 0644 00-hexagon-dsp-binaries.yaml ${DESTDIR}/${DSPDIR}/conf.d/00-hexagon-dsp-binaries.yaml
 
 TAG = $(shell git describe)
 NAME = hexagon-dsp-binaries

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024-2025 Linaro Ltd.
 
-import os, re, sys
+import os, re, sys, yaml
 
 def empty_data():
     return {'dirs': {}}
@@ -175,6 +175,60 @@ def list_git():
     if git.close():
         sys.stderr.write("WHENCE: skipped contents validation, git file listing failed\n")
 
+def load_machine_dsp_paths():
+    """Load and parse 00-hexagon-dsp-binaries.yaml to get valid DSP library paths."""
+    try:
+        with open("00-hexagon-dsp-binaries.yaml", encoding="utf-8") as file:
+            data = yaml.safe_load(file)
+            if not data or 'machines' not in data:
+                return set()
+
+            # Extract base paths (without /dsp suffix) from DSP_LIBRARY_PATH
+            paths = set()
+            for machine_name, machine_data in data['machines'].items():
+                if 'DSP_LIBRARY_PATH' in machine_data:
+                    dsp_path = machine_data['DSP_LIBRARY_PATH']
+                    # Remove /dsp suffix to get base path
+                    if dsp_path.endswith('/dsp'):
+                        base_path = dsp_path[:-4]
+                        paths.add(base_path)
+            return paths
+    except FileNotFoundError:
+        sys.stderr.write("Warning: 00-hexagon-dsp-binaries.yaml not found, skipping path consistency check\n")
+        return None
+    except Exception as e:
+        sys.stderr.write("Error loading 00-hexagon-dsp-binaries.yaml: %s\n" % e)
+        return None
+
+def check_config_against_machine_paths(config_data, machine_paths):
+    """Check that config.txt paths are consistent with 00-hexagon-dsp-binaries.yaml."""
+    if machine_paths is None:
+        return True
+
+    ret = True
+    reported_paths = set()  # Track paths we've already reported as missing
+
+    for data in config_data:
+        if data[0] == "install":
+            (lineno, path, dsp, subdir) = data[1:]
+            if path not in machine_paths and path not in reported_paths:
+                sys.stderr.write("config.txt: %d: Install path '%s' not found in 00-hexagon-dsp-binaries.yaml\n" % (lineno, path))
+                reported_paths.add(path)
+                ret = False
+        elif data[0] == "link":
+            (lineno, src_path, dst_path) = data[1:]
+            # Extract base path from link target (dst_path)
+            # Link format: path/to/device/dsp/dsptype
+            parts = dst_path.split('/')
+            if len(parts) >= 2 and parts[-2] == 'dsp':
+                base_path = '/'.join(parts[:-2])
+                if base_path not in machine_paths and base_path not in reported_paths:
+                    sys.stderr.write("config.txt: %d: Link target base path '%s' not found in 00-hexagon-dsp-binaries.yaml\n" % (lineno, base_path))
+                    reported_paths.add(base_path)
+                    ret = False
+
+    return ret
+
 def check_dir(subdir):
     pattern_shell = re.compile("^fastrpc_shell(_unsigned)?_[0-9]$")
     pattern_library = re.compile("^[-_+0-9a-zA-Z]*\\.so(\\.[0-9]*)?$")
@@ -212,7 +266,7 @@ def main():
         if 'licence' in data:
             licences[data['licence'][0]] = None
 
-    known_files = ['config.txt', 'Makefile', 'TODO', 'README.md', 'WHENCE']
+    known_files = ['config.txt', 'Makefile', 'TODO', 'README.md', 'WHENCE', '00-hexagon-dsp-binaries.yaml']
 
     for file in list_git():
         if os.path.dirname(file) in dirs:
@@ -233,13 +287,23 @@ def main():
         sys.stderr.write("WHENCE: file %s is not under a listed directory\n" % file)
         okay = False
 
+    # Load 00-hexagon-dsp-binaries.yaml for consistency checking
+    machine_paths = load_machine_dsp_paths()
+
+    # Collect config data for consistency check
+    config_data = []
     try:
         for data in load_config():
+            config_data.append(data)
             if not check_config(data, dirs):
                 okay = False
 
     except Exception as e:
         sys.stderr.write("%s\n" % e)
+        okay = False
+
+    # Check config.txt paths against 00-hexagon-dsp-binaries.yaml
+    if not check_config_against_machine_paths(config_data, machine_paths):
         okay = False
 
     for entry in dirs.keys():


### PR DESCRIPTION
Add DSP_LIBRARY_PATH entries in a new YAML file for the supported machines to enable consistent, machine-specific DSP library resolution.
The machine entries are sorted alphabetically by machine name to ensure maintainability and stability as new properties are added in the future. Also update the test script (check.py) to validate that paths in config.txt are consistent with entries in 00-hexagon-dsp-binaries.yaml, and update the Makefile to install the YAML file to the conf.d directory alongside the DSP binaries.