### PR TITLE
conf: specify the licence explicitly

### DIFF
--- a/00-hexagon-dsp-binaries.yaml
+++ b/00-hexagon-dsp-binaries.yaml
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
 # Machine entries are sorted alphabetically by machine name (key)
 # This sorting order ensures maintainability and stability as new properties are added
 machines:


### PR DESCRIPTION
As the rest of the non-binary files, the conf file is covered by the MIT licence. Add SPDX header to the file.