### PR TITLE
scripts/dist: add YAML configs to the dist tarball

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -55,4 +55,6 @@ done
 
 cp -r scripts/ Makefile config.txt ${DST}
 
+cp -r *.yaml ${DST}
+
 ./scripts/filter_whence.py config.txt WHENCE ${DST}/WHENCE


### PR DESCRIPTION
YAML config files are required by the userspace lib in order to be able to find DSP binaries. Add all provided config files to the generated tarball.

Fixes #45
