### PR TITLE
Add DSP_LIBRARY_PATH for Lemans Ride variants

### DIFF
--- a/00-hexagon-dsp-binaries.yaml
+++ b/00-hexagon-dsp-binaries.yaml
@@ -16,6 +16,10 @@ machines:
     DSP_LIBRARY_PATH: "kaanapali/Qualcomm/Kaanapali-MTP/dsp"
   "Qualcomm Technologies, Inc. Lemans EVK":
     DSP_LIBRARY_PATH: "sa8775p/Qualcomm/IQ9075-EVK/dsp"
+  "Qualcomm Technologies, Inc. Lemans Ride":
+    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
+  "Qualcomm Technologies, Inc. Lemans Ride Rev3":
+    DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
   "Qualcomm Technologies, Inc. Monaco EVK":
     DSP_LIBRARY_PATH: "qcs8300/Qualcomm/IQ8275-EVK/dsp"
   "Qualcomm Technologies, Inc. QCS615 Ride (IQ-615 Beta EVK)":


### PR DESCRIPTION
Add machine mappings for:
- "Qualcomm Technologies, Inc. Lemans Ride"
- "Qualcomm Technologies, Inc. Lemans Ride Rev3"

This fixes the fastrpc library config parser warning where DSP_LIBRARY_PATH is not found for "Qualcomm Technologies, Inc. Lemans Ride" in /usr/share/qcom/conf.d/00-hexagon-dsp-binaries.yaml, and ensures Lemans Ride boards resolve the expected DSP library directory.

Corresponding DTS files:
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/arch/arm64/boot/dts/qcom/qcs9100-ride.dts
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/arch/arm64/boot/dts/qcom/qcs9100-ride-r3.dts