### PR TITLE
Add DSP_LIBRARY_PATH for 615 EVK variants

### DIFF
--- a/00-hexagon-dsp-binaries.yaml
+++ b/00-hexagon-dsp-binaries.yaml
@@ -4,6 +4,8 @@
 # Machine entries are sorted alphabetically by machine name (key)
 # This sorting order ensures maintainability and stability as new properties are added
 machines:
+  "Qualcomm QCS615 IQ 615 EVK":
+    DSP_LIBRARY_PATH: "qcs615/Qualcomm/QCS615-RIDE/dsp"
   "Qualcomm SA8775P Ride":
     DSP_LIBRARY_PATH: "sa8775p/Qualcomm/SA8775P-RIDE/dsp"
   "Qualcomm SA8775P Ride Rev3":


### PR DESCRIPTION
Add machine mappings for:
- "Qualcomm QCS615 IQ 615 EVK"

This fixes the fastrpc library config parser warning where DSP_LIBRARY_PATH is not found for "Qualcomm QCS615 IQ 615 EVK" in /usr/share/qcom/conf.d/00-hexagon-dsp-binaries.yaml, and ensures 615 EVK boards resolve the expected DSP library directory.

Corresponding DTS files:
https://github.com/qualcomm-linux/kernel/blob/qcom-next/arch/arm64/boot/dts/qcom/talos-evk.dts