### PR TITLE
Makefile: fix release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,10 @@ dist:
 	$-rm -rf release
 	@mkdir -p release dist
 	./scripts/dist.sh config.txt release/$(SUBDIR)
+	tar -czf release/$(TARGET) -C release $(SUBDIR)
 	$(MAKE) -C release/$(SUBDIR) check
-	$(MAKE) -C release/$(SUBDIR) install DESTDIR=release/test-install-$(TAG)
-	tar -czf dist/$(TARGET) -C release $(SUBDIR)
+	$(MAKE) -C release/$(SUBDIR) install DESTDIR=$(CURDIR)/release/test-install-$(TAG)
+	mv release/$(TARGET) dist/$(TARGET)
 	@echo "Created dist/$(TARGET)"
 	@rm -rf release
 


### PR DESCRIPTION
Create tarball before testing the contents, preventing extra files from sneaking in. Also pass correct subdir for testing the instalation of the binaries.

Reported-by: Robie Basak <robie.basak@oss.qualcomm.com>