### PR TITLE
qcs8300: add links for Arduino Monza platform

### DIFF
--- a/00-hexagon-dsp-binaries.yaml
+++ b/00-hexagon-dsp-binaries.yaml
@@ -4,6 +4,8 @@
 # Machine entries are sorted alphabetically by machine name (key)
 # This sorting order ensures maintainability and stability as new properties are added
 machines:
+  "Arduino Monza":
+    DSP_LIBRARY_PATH: "qcs8300/Arduino/Monza/dsp"
   "Qualcomm QCS615 IQ 615 EVK":
     DSP_LIBRARY_PATH: "qcs615/Qualcomm/QCS615-RIDE/dsp"
   "Qualcomm SA8775P Ride":

--- a/config.txt
+++ b/config.txt
@@ -74,6 +74,11 @@ Install: kaanapali/Qualcomm/Kaanapali-MTP	cdsp	CDSP.HT.3.2-00726.1-KAANAPALI-1
 Install: glymur/Qualcomm/Glymur-CRD	adsp	LPAIDSP.HT.1.6.c1-00007-GLYMUR-3
 Install: glymur/Qualcomm/Glymur-CRD	cdsp	CDSP.HT.3.3-00302-GLYMUR-1
 
+# Arduino Monza
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Arduino/Monza/dsp/adsp
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Arduino/Monza/dsp/cdsp
+Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Arduino/Monza/dsp/gdsp0
+
 # IQ8275 EVK
 Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
 Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp


### PR DESCRIPTION
Add links for Arduino Monza platform based on monaco (qcs8300).
