### PR TITLE
conf.d: add QCM6490 IDP machine configuration

### DIFF
--- a/conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml
+++ b/conf.d/hexagon-dsp-binaries-qualcomm-qcm6490-idp.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+machines:
+  Qualcomm Technologies, Inc. QCM6490 IDP:
+    DSP_LIBRARY_PATH: qcm6490/Qualcomm/QCM6490-IDP/dsp

--- a/config.txt
+++ b/config.txt
@@ -94,3 +94,7 @@ Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp1	sa8775p/Qualcomm/IQ9075-EVK/dsp/gd
 # Purwa IoT EVK
 Link: x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp/adsp	x1p42100/Qualcomm/Purwa-IoT-EVK/dsp/adsp
 Link: x1e80100/Qualcomm/Hamoa-IoT-EVK/dsp/cdsp	x1p42100/Qualcomm/Purwa-IoT-EVK/dsp/cdsp
+
+# QCM6490 IDP
+Link: qcm6490/Thundercomm/RB3gen2/dsp/adsp      qcm6490/Qualcomm/QCM6490-IDP/dsp/adsp
+Link: qcm6490/Thundercomm/RB3gen2/dsp/cdsp      qcm6490/Qualcomm/QCM6490-IDP/dsp/cdsp


### PR DESCRIPTION
Reuse the RB3 Gen2 DSP library path for the QCM6490 IDP platform by adding a separate machine entry. This ensures the QCM6490 IDP target uses the correct DSP library path