### PR TITLE
qcs8300: rename Arduino Monza to VENTUNO Q

### DIFF
--- a/conf.d/hexagon-dsp-binaries-arduino-monza.yaml
+++ b/conf.d/hexagon-dsp-binaries-arduino-monza.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 machines:
-  Arduino Monza:
+  Arduino VENTUNO Q:
     DSP_LIBRARY_PATH: qcs8300/Arduino/Monza/dsp


### PR DESCRIPTION
The initial Device Tree used the Monza codename for this platform, but
the one merged in the upstream kernel is Arduino VENTUNO Q. Update the
name in the config to match.
