### PR TITLE
conf.d: add *_ARCH keys for legacy targets and extend schema

### DIFF
--- a/conf.d/hexagon-dsp-binaries-qualcomm-db410c.yaml
+++ b/conf.d/hexagon-dsp-binaries-qualcomm-db410c.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# yaml-language-server: $schema=schema.json
+machines:
+  Qualcomm Technologies, Inc. APQ 8016 SBC:
+    DSP_LIBRARY_PATH: apq8016/Qualcomm/db410c/dsp
+    ADSP_ARCH: v5

--- a/conf.d/hexagon-dsp-binaries-qualcomm-db820c.yaml
+++ b/conf.d/hexagon-dsp-binaries-qualcomm-db820c.yaml
@@ -4,3 +4,5 @@
 machines:
   Qualcomm Technologies, Inc. DB820c:
     DSP_LIBRARY_PATH: apq8096/Qualcomm/db820c/dsp
+    ADSP_ARCH: v60
+    SDSP_ARCH: v60

--- a/conf.d/hexagon-dsp-binaries-qualcomm-qcs615-ride.yaml
+++ b/conf.d/hexagon-dsp-binaries-qualcomm-qcs615-ride.yaml
@@ -4,5 +4,9 @@
 machines:
   Qualcomm QCS615 IQ 615 EVK:
     DSP_LIBRARY_PATH: qcs615/Qualcomm/QCS615-RIDE/dsp
+    ADSP_ARCH: v66
+    CDSP_ARCH: v66
   Qualcomm Technologies, Inc. QCS615 Ride (IQ-615 Beta EVK):
     DSP_LIBRARY_PATH: qcs615/Qualcomm/QCS615-RIDE/dsp
+    ADSP_ARCH: v66
+    CDSP_ARCH: v66

--- a/conf.d/hexagon-dsp-binaries-thundercomm-db845c.yaml
+++ b/conf.d/hexagon-dsp-binaries-thundercomm-db845c.yaml
@@ -4,3 +4,6 @@
 machines:
   Thundercomm Dragonboard 845c:
     DSP_LIBRARY_PATH: sdm845/Thundercomm/db845c/dsp
+    ADSP_ARCH: v65
+    CDSP_ARCH: v65
+    SDSP_ARCH: v65

--- a/conf.d/schema.json
+++ b/conf.d/schema.json
@@ -19,6 +19,22 @@
             "DSP_LIBRARY_PATH": {
               "type": "string",
               "pattern": "^([^/]+/)+dsp$"
+            },
+            "ADSP_ARCH": {
+              "type": "string",
+              "pattern": "^v[0-9a-f]+$"
+            },
+            "MDSP_ARCH": {
+              "type": "string",
+              "pattern": "^v[0-9a-f]+$"
+            },
+            "SDSP_ARCH": {
+              "type": "string",
+              "pattern": "^v[0-9a-f]+$"
+            },
+            "CDSP_ARCH": {
+              "type": "string",
+              "pattern": "^v[0-9a-f]+$"
             }
           }
         }


### PR DESCRIPTION
Legacy targets (db820c, db845c, qcs615-ride) do not implement the ARCH_VER capability on the DSP, so fastrpc cannot auto-detect the Hexagon version at runtime. This adds explicit *_ARCH keys in the per-machine YAML configs so fastrpc can resolve the correct DSP library search path (e.g. /usr/share/qcom/hexagon/v\<XY>/).

  YAML changes:
  - db410c: ADSP_ARCH=v5
  - db820c: ADSP_ARCH=v60, SDSP_ARCH=v60
  - db845c: ADSP_ARCH=v65, CDSP_ARCH=v65, SDSP_ARCH=v65
  - qcs615-ride: ADSP_ARCH=v66, CDSP_ARCH=v66

  Schema changes (conf.d/schema.json):
  - Register all *_ARCH keys as optional properties: ADSP_ARCH, MDSP_ARCH, SDSP_ARCH, CDSP_ARCH
  - Pattern ^v[0-9a-f]+$ allows hex-digit version strings (e.g. v60, v65, v6a)

Depends on [qualcomm/fastrpc#328](https://github.com/qualcomm/fastrpc/pull/328)