### PR TITLE
qcs8300: drop separate adsp/gdsp0 binaries

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -50,9 +50,9 @@ Install: sa8775p/Qualcomm/SA8775P-RIDE	gdsp0	gdsp0-DSP.AT.1.0.1-00204-LEMANS-1
 Install: sa8775p/Qualcomm/SA8775P-RIDE	gdsp1	gdsp1-DSP.AT.1.0.1-00204-LEMANS-1
 
 # QCS8300 RIDE
-Install: qcs8300/Qualcomm/QCS8300-RIDE	adsp	adsp-DSP.AT.1.0.1-00204-LEMANS-1
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp
 Install: qcs8300/Qualcomm/QCS8300-RIDE	cdsp	cdsp-DSP.AT.1.0.1-00204-LEMANS-1
-Install: qcs8300/Qualcomm/QCS8300-RIDE	gdsp0	gdsp0-DSP.AT.1.0.1-00204-LEMANS-1
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0
 
 # QCS615 RIDE
 Install: qcs615/Qualcomm/QCS615-RIDE	adsp	ADSP.VT.5.2.c6-00073-SM6150-1
@@ -91,14 +91,14 @@ Link: shikra/Qualcomm/Shikra-CQS-EVK/dsp/cdsp	shikra/Qualcomm/Shikra-CQM-EVK/dsp
 Link: shikra/Qualcomm/Shikra-CQS-EVK/dsp/cdsp	shikra/Qualcomm/Shikra-IQS-EVK/dsp/cdsp
 
 # Arduino Monza
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Arduino/Monza/dsp/adsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Arduino/Monza/dsp/cdsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Arduino/Monza/dsp/gdsp0
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	qcs8300/Arduino/Monza/dsp/adsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp	qcs8300/Arduino/Monza/dsp/cdsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	qcs8300/Arduino/Monza/dsp/gdsp0
 
 # IQ8275 EVK
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
-Link: qcs8300/Qualcomm/QCS8300-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/adsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/cdsp	qcs8300/Qualcomm/IQ8275-EVK/dsp/cdsp
+Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/gdsp0	qcs8300/Qualcomm/IQ8275-EVK/dsp/gdsp0
 
 # IQ9075 EVK
 Link: sa8775p/Qualcomm/SA8775P-RIDE/dsp/adsp	sa8775p/Qualcomm/IQ9075-EVK/dsp/adsp


### PR DESCRIPTION
Binaries for ADSP and GDSP0 on Monaco platforms are identical to the corresponding binaries on the Lemans platform. Stop installing the duplicates and replace them with the links.